### PR TITLE
Storage get count

### DIFF
--- a/models/engine/db_storage.py
+++ b/models/engine/db_storage.py
@@ -74,3 +74,19 @@ class DBStorage:
     def close(self):
         """call remove() method on the private session attribute"""
         self.__session.remove()
+
+    def get(self, cls, id):
+        """Retrieve one object"""
+        if cls and id:
+            key = "{}.{}".format(cls.__name__, id)
+            return self.__session.query(cls).filter_by(id=id).first()
+        return None
+
+    def count(self, cls=None):
+        """Count number of objects in storage"""
+        if cls:
+            return self.__session.query(cls).count()
+        total_count = 0
+        for clss in classes.values():
+            total_count += self.__session.query(clss).count()
+        return total_count

--- a/models/engine/file_storage.py
+++ b/models/engine/file_storage.py
@@ -68,3 +68,16 @@ class FileStorage:
     def close(self):
         """call reload() method for deserializing the JSON file to objects"""
         self.reload()
+
+    def get(self, cls, id):
+        """Retrieve one object"""
+        if cls and id:
+            key = "{}.{}".format(cls.__name__, id)
+            return self.__objects.get(key)
+        return None
+
+    def count(self, cls=None):
+        """Count number of objects in storage"""
+        if cls:
+            return len([obj for obj in self.__objects.values() if isinstance(obj, cls)])
+        return len(self.__objects)

--- a/tests/test_models/test_engine/test_db_storage.py
+++ b/tests/test_models/test_engine/test_db_storage.py
@@ -67,6 +67,27 @@ test_db_storage.py'])
             self.assertTrue(len(func[1].__doc__) >= 1,
                             "{:s} method needs a docstring".format(func[0]))
 
+    def test_get(self):
+        """Test get method in DBStorage"""
+        new_state = State(name="Bourgogne")
+        new_state.save()
+        state_id = new_state.id
+        self.assertEqual(models.storage.get(State, state_id), new_state)
+
+    def test_count_all_objects(self):
+        """Test count method in DBStorage for all objects"""
+        num_objects = len(models.storage.all())
+        s = State(name="Yonne")
+        s.save()
+        self.assertEqual(models.storage.count(), num_objects + 1)
+
+    def test_count_specific_class(self):
+        """Test count method in DBStorage for a specific class"""
+        num_states = len(models.storage.all(State))
+        s = State(name="Yonne")
+        s.save()
+        self.assertEqual(models.storage.count(State), num_states + 1)
+
 
 class TestFileStorage(unittest.TestCase):
     """Test the FileStorage class"""

--- a/tests/test_models/test_engine/test_file_storage.py
+++ b/tests/test_models/test_engine/test_file_storage.py
@@ -3,21 +3,23 @@
 Contains the TestFileStorageDocs classes
 """
 
-from datetime import datetime
 import inspect
+import json
+import os
+import unittest
+from datetime import datetime
+import pep8
 import models
-from models.engine import file_storage
+from models import storage
 from models.amenity import Amenity
 from models.base_model import BaseModel
 from models.city import City
+from models.engine import file_storage
 from models.place import Place
 from models.review import Review
 from models.state import State
 from models.user import User
-import json
-import os
-import pep8
-import unittest
+
 FileStorage = file_storage.FileStorage
 classes = {"Amenity": Amenity, "BaseModel": BaseModel, "City": City,
            "Place": Place, "Review": Review, "State": State, "User": User}
@@ -66,6 +68,28 @@ test_file_storage.py'])
                              "{:s} method needs a docstring".format(func[0]))
             self.assertTrue(len(func[1].__doc__) >= 1,
                             "{:s} method needs a docstring".format(func[0]))
+
+    @unittest.skipIf(models.storage_t == 'db', "not testing db storage")
+    def test_get(self):
+        """Test the get method"""
+        storage = FileStorage()
+        new_state = State(name='Holberton')
+        storage.new(new_state)
+        storage.save()
+
+        # Test getting an object that exists
+        get_state = storage.get(State, new_state.id)
+        self.assertEqual(get_state, new_state)
+
+        # Test getting an object that doesn't exist
+        non_existent_state = storage.get(State, 'nonexistent_id')
+        self.assertIsNone(non_existent_state)
+
+    @unittest.skipIf(models.storage_t == 'db', "not testing file storage")
+    def test_count(self):
+        """Test that get resturns one object"""
+        self.assertIsInstance(storage.count(), int)
+        self.assertIsInstance(storage.count(State), int)
 
 
 class TestFileStorage(unittest.TestCase):


### PR DESCRIPTION
Update DBStorage and FileStorage, adding two new methods. All changes should be done in the branch storage_get_count:

A method to retrieve one object:

Prototype: def get(self, cls, id):
cls: class
id: string representing the object ID
Returns the object based on the class and its ID, or None if not found
A method to count the number of objects in storage:

Prototype: def count(self, cls=None):
cls: class (optional)
Returns the number of objects in storage matching the given class. If no class is passed, returns the count of all objects in storage.
Don’t forget to add new tests for these 2 methods on each storage engine.